### PR TITLE
Fix a bug that made contract key fields strings accidently

### DIFF
--- a/behavioural_contracts/generator.py
+++ b/behavioural_contracts/generator.py
@@ -38,53 +38,44 @@ def generate_contract(spec_data: Dict[str, Any]) -> str:
         }
     }
     """
-    # Format all values as strings
+    # Format values preserving their types
     formatted = {
-        "version": str(spec_data.get("version", "1.1")),
-        "description": str(spec_data.get("description", "")),
-        "role": str(spec_data.get("role", "")),
+        "version": str(
+            spec_data.get("version", "1.1")
+        ),  # Always convert version to string
+        "description": spec_data.get("description", ""),
+        "role": spec_data.get("role", ""),
         "memory": {
-            "enabled": str(spec_data.get("memory", {}).get("enabled", False)).lower(),
-            "format": str(spec_data.get("memory", {}).get("format", "string")),
-            "usage": str(spec_data.get("memory", {}).get("usage", "prompt-append")),
-            "required": str(spec_data.get("memory", {}).get("required", False)).lower(),
-            "description": str(spec_data.get("memory", {}).get("description", "")),
+            "enabled": spec_data.get("memory", {}).get("enabled", False),
+            "format": spec_data.get("memory", {}).get("format", "string"),
+            "usage": spec_data.get("memory", {}).get("usage", "prompt-append"),
+            "required": spec_data.get("memory", {}).get("required", False),
+            "description": spec_data.get("memory", {}).get("description", ""),
         },
     }
 
     # Add policy if present
     if "policy" in spec_data:
         formatted["policy"] = {
-            "pii": str(spec_data["policy"].get("pii", False)).lower(),
-            "compliance_tags": [
-                str(tag) for tag in spec_data["policy"].get("compliance_tags", [])
-            ],
-            "allowed_tools": [
-                str(tool) for tool in spec_data["policy"].get("allowed_tools", [])
-            ],
+            "pii": spec_data["policy"].get("pii", False),
+            "compliance_tags": spec_data["policy"].get("compliance_tags", []),
+            "allowed_tools": spec_data["policy"].get("allowed_tools", []),
         }
 
     # Add behavioural flags if present
     if "behavioural_flags" in spec_data:
         formatted["behavioural_flags"] = {
-            "conservatism": str(
-                spec_data["behavioural_flags"].get("conservatism", "moderate")
+            "conservatism": spec_data["behavioural_flags"].get(
+                "conservatism", "moderate"
             ),
-            "verbosity": str(
-                spec_data["behavioural_flags"].get("verbosity", "compact")
-            ),
+            "verbosity": spec_data["behavioural_flags"].get("verbosity", "compact"),
             "temperature_control": {
-                "mode": str(
-                    spec_data["behavioural_flags"]["temperature_control"].get(
-                        "mode", "adaptive"
-                    )
+                "mode": spec_data["behavioural_flags"]["temperature_control"].get(
+                    "mode", "adaptive"
                 ),
-                "range": [
-                    float(x)
-                    for x in spec_data["behavioural_flags"]["temperature_control"].get(
-                        "range", [0.2, 0.6]
-                    )
-                ],
+                "range": spec_data["behavioural_flags"]["temperature_control"].get(
+                    "range", [0.2, 0.6]
+                ),
             },
         }
 

--- a/tests/test_contract_generation.py
+++ b/tests/test_contract_generation.py
@@ -23,10 +23,10 @@ def test_generate_contract_basic():
     assert parsed["version"] == "1.1"
     assert parsed["description"] == "Test agent"
     assert parsed["role"] == "test"
-    assert parsed["memory"]["enabled"] == "true"
+    assert parsed["memory"]["enabled"] is True
     assert parsed["memory"]["format"] == "string"
     assert parsed["memory"]["usage"] == "prompt-append"
-    assert parsed["memory"]["required"] == "true"
+    assert parsed["memory"]["required"] is True
     assert parsed["memory"]["description"] == "Test context"
 
 
@@ -45,7 +45,7 @@ def test_generate_contract_with_policy():
     result = generate_contract(spec_data)
     parsed = json.loads(result)
 
-    assert parsed["policy"]["pii"] == "false"
+    assert parsed["policy"]["pii"] is False
     assert parsed["policy"]["compliance_tags"] == ["TEST-TAG"]
     assert parsed["policy"]["allowed_tools"] == ["test_tool"]
 
@@ -73,14 +73,14 @@ def test_generate_contract_with_behavioural_flags():
 
 def test_format_contract():
     contract = {
-        "version": 1.1,  # Should be converted to string
+        "version": 1.1,
         "description": "Test agent",
         "role": "test",
         "memory": {
-            "enabled": True,  # Should be converted to "true"
+            "enabled": True,
             "format": "string",
             "usage": "prompt-append",
-            "required": True,  # Should be converted to "true"
+            "required": True,
             "description": "Test context",
         },
     }
@@ -88,9 +88,10 @@ def test_format_contract():
     result = format_contract(contract)
     parsed = json.loads(result)
 
+    assert isinstance(parsed["version"], str)
     assert parsed["version"] == "1.1"
-    assert parsed["memory"]["enabled"] == "true"
-    assert parsed["memory"]["required"] == "true"
+    assert parsed["memory"]["enabled"] is True
+    assert parsed["memory"]["required"] is True
 
 
 def test_generate_contract_defaults():
@@ -99,9 +100,37 @@ def test_generate_contract_defaults():
     result = generate_contract(spec_data)
     parsed = json.loads(result)
 
-    # Check default values
-    assert parsed["memory"]["enabled"] == "false"
+    assert parsed["memory"]["enabled"] is False
     assert parsed["memory"]["format"] == "string"
     assert parsed["memory"]["usage"] == "prompt-append"
-    assert parsed["memory"]["required"] == "false"
+    assert parsed["memory"]["required"] is False
     assert parsed["memory"]["description"] == ""
+
+
+def test_generate_contract_with_mixed_types():
+    spec_data = {
+        "version": 1.1,
+        "description": "Test agent",
+        "role": "test",
+        "memory": {
+            "enabled": "true",
+            "format": "string",
+            "usage": "prompt-append",
+            "required": 1,
+            "description": "Test context",
+        },
+        "policy": {
+            "pii": "false",
+            "compliance_tags": ["TEST-TAG"],
+            "allowed_tools": ["test_tool"],
+        },
+    }
+
+    result = generate_contract(spec_data)
+    parsed = json.loads(result)
+
+    assert isinstance(parsed["version"], str)
+    assert parsed["version"] == "1.1"
+    assert parsed["memory"]["enabled"] == "true"
+    assert parsed["memory"]["required"] == 1
+    assert parsed["policy"]["pii"] == "false"


### PR DESCRIPTION
- Fix a bug that caused the generated contract to have fields as strings instead of types